### PR TITLE
Fix hydra warnings

### DIFF
--- a/hsf/conf/config.yaml
+++ b/hsf/conf/config.yaml
@@ -6,3 +6,8 @@ defaults:
   - multispectrality: default
   - hardware: onnxruntime
   - override hydra/help: hsf
+  - _self_
+
+hydra:
+  job:
+    chdir: true

--- a/hsf/factory.py
+++ b/hsf/factory.py
@@ -144,7 +144,7 @@ def save(mri: PosixPath, hippocampus: PosixPath, hard_pred: torch.Tensor,
     log.info(f"Saved segmentation in native space to {str(output_path)}")
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra.main(config_path="conf", config_name="config", version_base="1.1")
 def main(cfg: DictConfig) -> None:
     fetch_models(cfg.segmentation.models_path, cfg.segmentation.models)
 


### PR DESCRIPTION
# Description

Fix a couple of hydra-related warnings that appear at `hsf` start-up time.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

* OS: Ubuntu 22.04
* Python version: 3.10.12
* Any other relevant config detail: `hydra-core==1.3.2`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
