### PR TITLE
fix: remove irrelevant warning

### DIFF
--- a/hsf/segment.py
+++ b/hsf/segment.py
@@ -105,7 +105,7 @@ def predict(mris: list,
                                affine=aug.mri.affine)
         aug.add_image(lm_temp, 'label')
         aug.label.set_data(lab)
-        back = aug.apply_inverse_transform(warn=True)
+        back = aug.apply_inverse_transform(warn=False)
         results.append(back.label.data)
 
     return results


### PR DESCRIPTION
A warning about Z-normalization being non-invertible used to appeare systematically, which was completely normal: Z-normalization is applied to the input images, but it is not supposed to be inverted on the output segmentations.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:

* OS: Ubuntu 22.04
* Python version: 3.10.12

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
