### PR TITLE
fix: use distinct directory for bagging_sq models

### DIFF
--- a/hsf/conf/segmentation/bagging_sq.yaml
+++ b/hsf/conf/segmentation/bagging_sq.yaml
@@ -5,7 +5,7 @@
 # Current version: 3.0.0
 
 ca_mode: "1/2/3"
-models_path: "~/.hsf/models/bagging/"
+models_path: "~/.hsf/models/bagging_sq/"
 models:
   arunet_bag_0.onnx:
     url: "https://zenodo.org/record/6482419/files/arunet_3.0.0_85sparse_qat_bag0.onnx?download=1"


### PR DESCRIPTION
# Description

Previously, sparse+quantized models would overwrite the regular dense+floating models (and vice versa) because they were stored with the same filename in the same directory. Models would be downloaded again from Zenodo every time the user switched between the two...

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
